### PR TITLE
Serialize the endOfLife field on AbstractToken

### DIFF
--- a/src/OAuth/Common/Token/AbstractToken.php
+++ b/src/OAuth/Common/Token/AbstractToken.php
@@ -125,6 +125,6 @@ abstract class AbstractToken implements TokenInterface
 
     public function __sleep()
     {
-        return ['accessToken'];
+        return ['accessToken', 'endOfLife'];
     }
 }


### PR DESCRIPTION
Otherwise, after serialize/deserialize the AbstractToken is incorrectly determined to be expired when making an authentication request (ExpiredTokenException is thrown because endOfLife is null).

It looks like this was introduced by f08a062d5abe903a4092bcf92f855f6e2e7b676a